### PR TITLE
Allow base 4.15 and tasty 1.4.* for GHC 9 compatibility

### DIFF
--- a/cryptohash-sha512.cabal
+++ b/cryptohash-sha512.cabal
@@ -44,7 +44,7 @@ source-repository head
 
 library
   default-language:  Haskell2010
-  build-depends:     base             >= 4.5   && < 4.12
+  build-depends:     base             >= 4.5   && < 4.16
                    , bytestring       >= 0.9.2 && < 0.11
 
   hs-source-dirs:    src
@@ -66,7 +66,7 @@ test-suite test-sha512
 
                    , base16-bytestring >= 0.1.1  && < 0.2
                    , SHA               >= 1.6.4  && < 1.7
-                   , tasty             == 0.11.* || == 0.12.* || == 1.0.*
+                   , tasty             == 0.11.* || == 0.12.* || == 1.0.* || == 1.4.*
                    , tasty-quickcheck  >= 0.8    && < 0.11
                    , tasty-hunit       >= 0.9    && < 0.11
 


### PR DESCRIPTION
This was tested with "cabal test" (Cabal 3.4) and GHC 9.0.1 and it passed. There is no sha512sum executable, so I could not test that.