### PR TITLE
v0.11.102.0-r1: GHCs 9.8 and 9.6 and bytestring-0.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220808
+# version: 0.16.6.20230729
 #
-# REGENDATA ("0.15.20220808",["github","cabal.project"])
+# REGENDATA ("0.16.6.20230729",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,14 +32,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.1
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.4.1
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.4.5
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.4.5
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -105,18 +110,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -134,13 +139,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
@@ -192,14 +197,14 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -226,6 +231,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package cryptohash-sha512" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: bytestring
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(cryptohash-sha512)$/; }' >> cabal.project.local
           cat cabal.project
@@ -234,8 +240,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -259,7 +265,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
@@ -267,8 +273,16 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
-      - name: constraint set bytestring-0.11
+      - name: constraint set bytestring-0.12
         run: |
-          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ==0.11.*' --dependencies-only -j2 all
-          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ==0.11.*' all
-          $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ==0.11.*' all
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ==0.12.*' all --dry-run ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ==0.12.*' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ==0.12.*' all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ==0.12.*' all ; fi
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        ghc: ['8.10','9.0','9.2','9.4.1']
+        ghc: ['8.10','9.0','9.2','9.4','9.6']
       fail-fast: false
     timeout-minutes:
       60
@@ -25,21 +25,25 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
 
       - name: Set up Haskell
         id: setup-haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: '3.8.1.0'
+          cabal-version: latest
+
+      - name: Get precise GHC version
+        shell: bash
+        run: echo "GHC_VERSION=$(ghc --numeric-version)" >> "${GITHUB_ENV}"
 
       - name: Cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ env.GHC_VERSION }}-
 
       - name: Build
         run: cabal build all --enable-tests

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,7 +2,11 @@ branches: master
 benchmarks: >=7.6
 tests: >=7.6
 
-constraint-set bytestring-0.11
-  constraints: bytestring ==0.11.*
+constraint-set bytestring-0.12
+  constraints: bytestring ==0.12.*
+  ghc: >=8.2
   tests: True
   run-tests: True
+
+raw-project
+  allow-newer: bytestring

--- a/cryptohash-sha512.cabal
+++ b/cryptohash-sha512.cabal
@@ -51,19 +51,22 @@ homepage:            https://github.com/hvr/cryptohash-sha512
 bug-reports:         https://github.com/hvr/cryptohash-sha512/issues
 category:            Data, Cryptography
 build-type:          Simple
-tested-with:         GHC == 7.4.2
-                   , GHC == 7.6.3
-                   , GHC == 7.8.4
-                   , GHC == 7.10.3
-                   , GHC == 8.0.2
-                   , GHC == 8.2.2
-                   , GHC == 8.4.4
-                   , GHC == 8.6.5
-                   , GHC == 8.8.4
-                   , GHC == 8.10.7
-                   , GHC == 9.0.2
-                   , GHC == 9.2.4
-                   , GHC == 9.4.1
+
+tested-with:
+  GHC == 9.6.2
+  GHC == 9.4.5
+  GHC == 9.2.8
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
+  GHC == 7.8.4
+  GHC == 7.6.3
+  GHC == 7.4.2
 
 extra-source-files:  cbits/hs_sha512.h
                      changelog.md

--- a/cryptohash-sha512.cabal
+++ b/cryptohash-sha512.cabal
@@ -1,6 +1,7 @@
 cabal-version:       2.0
 name:                cryptohash-sha512
 version:             0.11.102.0
+x-revision:          1
 
 synopsis:            Fast, pure and practical SHA-512 implementation
 description: {
@@ -47,8 +48,8 @@ license:             BSD3
 license-file:        LICENSE
 copyright:           Vincent Hanquez, Herbert Valerio Riedel
 maintainer:          Herbert Valerio Riedel <hvr@gnu.org>
-homepage:            https://github.com/hvr/cryptohash-sha512
-bug-reports:         https://github.com/hvr/cryptohash-sha512/issues
+homepage:            https://github.com/haskell-hvr/cryptohash-sha512
+bug-reports:         https://github.com/haskell-hvr/cryptohash-sha512/issues
 category:            Data, Cryptography
 build-type:          Simple
 
@@ -73,12 +74,12 @@ extra-source-files:  cbits/hs_sha512.h
 
 source-repository head
   type:     git
-  location: https://github.com/hvr/cryptohash-sha512.git
+  location: https://github.com/haskell-hvr/cryptohash-sha512.git
 
 library
   default-language:  Haskell2010
-  build-depends:     base             >= 4.5   && < 4.18
-                   , bytestring       >= 0.9.2 && < 0.12
+  build-depends:     base             >= 4.5   && < 4.20
+                   , bytestring       >= 0.9.2 && < 0.13
 
   hs-source-dirs:    src
   exposed-modules:   Crypto.Hash.SHA512 Crypto.Hash.SHA512t Crypto.Hash.SHA384


### PR DESCRIPTION
- Update CI simple.yml
- Bump Haskell CI to GHC 9.6.2 and bytestring-0.12
- v0.11.102.0-r1: allow base <4.20 and bytestring-0.12
